### PR TITLE
Adjust args for 4.4 change

### DIFF
--- a/php/PostType/ArchiveHookProvider.php
+++ b/php/PostType/ArchiveHookProvider.php
@@ -116,7 +116,7 @@ class ArchiveHookProvider {
 			// This allows the slug to be edited. Rules won't be generated.
 			'rewrite'                    => 'cpt_archive',
 			'query_var'                  => false,
-			'show_ui'                    => false,
+			'show_ui'                    => true,
 			'show_in_admin_bar'          => false,
 			'show_in_menu'               => false,
 			'show_in_nav_menus'          => true,


### PR DESCRIPTION
https://core.trac.wordpress.org/changeset/34177 makes editing screens inaccessible when `show_ui` is set to false.
